### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Chris Bruner
 maintainer=Chris <cwbruner@gmail.com>
 sentence=Allows a servo to move at a slower speed then immediately. 
 paragraph=By calculating the time to reach the goal and adding in time segments to each degree, a servo can be made to slowly reach it's goal by having many subgoals.
-Category=Control
+category=Device Control
 url=https://github.com/iplayfast/TimedServo
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library TimedServo is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format