### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,20 +7,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-goal KEYWORD1
+goal	KEYWORD1
 pos	KEYWORD1
-Distance KEYWORD1
+Distance	KEYWORD1
 write	KEYWORD1
-lastTime KEYWORD1
+lastTime	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-SetAngle KEYWORD2
+SetAngle	KEYWORD2
 Update	KEYWORD2
-SetLastTime KEYWORD2
-TimePassed KEYWORD2
+SetLastTime	KEYWORD2
+TimePassed	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords